### PR TITLE
fix: correct backend service port to 80 in demo-http-route.yaml

### DIFF
--- a/demo/demo-http-route.yaml
+++ b/demo/demo-http-route.yaml
@@ -15,5 +15,5 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 80
 ---


### PR DESCRIPTION
The backend service port in demo-http-route.yaml was incorrectly set to 8080 while the demo service exposes port 80. This fix aligns the port to 80 to enable proper routing from Istio ingress gateway to the demo service.